### PR TITLE
[MAKI-122][iOS] Скрыть footerview в историях

### DIFF
--- a/maki-maki-ios/Orders/OrdersViewController.swift
+++ b/maki-maki-ios/Orders/OrdersViewController.swift
@@ -14,25 +14,25 @@ final class OrdersViewController: UIViewController {
     lazy var orders: [Order] = {
         return [
             Order(cafeName: "Bellissimo Pizza",
-                        status: "Delivered",
-                        time: "31 May 2020, 07:55 PM  ",
-                        price: "$43.95",
-                        ordersList: self.firstOrder),
+                  status: "Delivered",
+                  time: "31 May 2020, 07:55 PM  ",
+                  price: "$43.95",
+                  ordersList: self.firstOrder),
             Order(cafeName: "Capital One Cafe",
-                        status: "Cancelled",
-                        time: "24 May 2020, 04:50 PM  ",
-                        price: "$5.48",
-                        ordersList: self.secondOrder),
+                  status: "Cancelled",
+                  time: "24 May 2020, 04:50 PM  ",
+                  price: "$5.48",
+                  ordersList: self.secondOrder),
             Order(cafeName: "Street Cafe",
-                        status: "Delivered",
-                        time: "18 May 2020, 02:37 PM  ",
-                        price: "$18.30",
-                        ordersList: self.thirdOrder),
+                  status: "Delivered",
+                  time: "18 May 2020, 02:37 PM  ",
+                  price: "$18.30",
+                  ordersList: self.thirdOrder),
             Order(cafeName: "Smile House Cafe",
-                        status: "Delivered",
-                        time: "18 May 2020, 02:08 PM  ",
-                        price: "$14.00",
-                        ordersList: self.fouthOrder)
+                  status: "Delivered",
+                  time: "18 May 2020, 02:08 PM  ",
+                  price: "$14.00",
+                  ordersList: self.fouthOrder)
         ]
     }()
     
@@ -212,8 +212,8 @@ extension OrdersViewController: OrdersTableHeaderViewDelegate {
     func onCollapseMenuButtonDidPressed(section: Int, isExpanded: Bool) {
         sectionIsExpanded[section] = !sectionIsExpanded[section]
         isReorderCellExpanded[section] = isExpanded
-        
         ordersTableView.reloadData()
+        
         if !isExpanded {
             orders[section].ordersList = []
             ordersTableView.reloadData()

--- a/maki-maki-ios/Orders/OrdersViewController.swift
+++ b/maki-maki-ios/Orders/OrdersViewController.swift
@@ -69,7 +69,6 @@ final class OrdersViewController: UIViewController {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.register(OrdersCell.self, forCellReuseIdentifier: OrdersCell.reuseID)
         tableView.register(ReorderCell.self, forCellReuseIdentifier: ReorderCell.reuseID)
-        tableView.rowHeight = 36
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
@@ -139,6 +138,7 @@ final class OrdersViewController: UIViewController {
 // MARK: - UITableView Data Source and Delegate methods
 
 extension OrdersViewController: UITableViewDataSource, UITableViewDelegate {
+    
     func numberOfSections(in tableView: UITableView) -> Int {
         return orders.count
     }
@@ -203,8 +203,8 @@ extension OrdersViewController: UITableViewDataSource, UITableViewDelegate {
 extension OrdersViewController: OrdersTableHeaderViewDelegate {
     func onCollapseMenuButtonDidPressed(section: Int, isExpanded: Bool) {
         var indexPathes: [IndexPath] = []
-        for i in stride(from: 0, to: ordersCopy[section].ordersList.count, by: 1) {
-            indexPathes.append(IndexPath(row: i, section: section))
+        for row in stride(from: 0, to: ordersCopy[section].ordersList.count, by: 1) {
+            indexPathes.append(IndexPath(row: row, section: section))
         }
         sectionIsExpanded[section] = !sectionIsExpanded[section]
         if !isExpanded {


### PR DESCRIPTION
Доработка бага с логикой скрытия ReorderCell

Теперь все заказы будут корректно отображаться и после всех заказов в секции будет отображаться отдельная ячейка с reorderButton.

Просьба обратить внимание на реализацию логики. 

Ссылка на таск:
https://startmobile.atlassian.net/browse/MAKI-122


https://github.com/startmobile-kz/makimaki.kz/assets/99109874/afb7e33c-649e-47b1-81a6-f62e57caae4d


